### PR TITLE
Create simple Shader framework

### DIFF
--- a/include/rg/renderer/shader/Shader.hpp
+++ b/include/rg/renderer/shader/Shader.hpp
@@ -21,6 +21,7 @@ public:
     void unbind() const;
 
     void set(const std::string& uniform, float value) const;
+    void set(const std::string& uniform, int value) const;
     void set(const std::string& uniform, const glm::vec2& value) const;
     void set(const std::string& uniform, const glm::vec3& value) const;
     void set(const std::string& uniform, const glm::vec4& value) const;

--- a/include/rg/renderer/shader/Shader.hpp
+++ b/include/rg/renderer/shader/Shader.hpp
@@ -31,7 +31,7 @@ public:
 private:
     // NOLINTNEXTLINE(google-explicit-constructor)
     Shader(unsigned int id);
-    int get_uniform_location(const std::string& name);
+    [[nodiscard]] int get_uniform_location(const std::string& name) const;
     unsigned int shader_id_;
 };
 

--- a/include/rg/renderer/shader/Shader.hpp
+++ b/include/rg/renderer/shader/Shader.hpp
@@ -20,13 +20,13 @@ public:
     void bind() const;
     void unbind() const;
 
-    void set(const std::string& uniform, float value);
-    void set(const std::string& uniform, const glm::vec2& value);
-    void set(const std::string& uniform, const glm::vec3& value);
-    void set(const std::string& uniform, const glm::vec4& value);
-    void set(const std::string& uniform, const glm::mat2x2& value);
-    void set(const std::string& uniform, const glm::mat3x3& value);
-    void set(const std::string& uniform, const glm::mat4x4& value);
+    void set(const std::string& uniform, float value) const;
+    void set(const std::string& uniform, const glm::vec2& value) const;
+    void set(const std::string& uniform, const glm::vec3& value) const;
+    void set(const std::string& uniform, const glm::vec4& value) const;
+    void set(const std::string& uniform, const glm::mat2x2& value) const;
+    void set(const std::string& uniform, const glm::mat3x3& value) const;
+    void set(const std::string& uniform, const glm::mat4x4& value) const;
 
 private:
     // NOLINTNEXTLINE(google-explicit-constructor)

--- a/include/rg/renderer/shader/Shader.hpp
+++ b/include/rg/renderer/shader/Shader.hpp
@@ -1,12 +1,12 @@
 #ifndef RG_RENDERER_SHADER_SHADER_HPP
 #define RG_RENDERER_SHADER_SHADER_HPP
 
-#include <glm/vec2.hpp>
-#include <glm/vec3.hpp>
-#include <glm/vec4.hpp>
 #include <glm/mat2x2.hpp>
 #include <glm/mat3x3.hpp>
 #include <glm/mat4x4.hpp>
+#include <glm/vec2.hpp>
+#include <glm/vec3.hpp>
+#include <glm/vec4.hpp>
 
 #include <string>
 
@@ -27,6 +27,7 @@ public:
     void set(const std::string& uniform, const glm::mat2x2& value);
     void set(const std::string& uniform, const glm::mat3x3& value);
     void set(const std::string& uniform, const glm::mat4x4& value);
+
 private:
     // NOLINTNEXTLINE(google-explicit-constructor)
     Shader(unsigned int id);

--- a/include/rg/renderer/shader/Shader.hpp
+++ b/include/rg/renderer/shader/Shader.hpp
@@ -1,0 +1,39 @@
+#ifndef RG_RENDERER_SHADER_SHADER_HPP
+#define RG_RENDERER_SHADER_SHADER_HPP
+
+#include <glm/vec2.hpp>
+#include <glm/vec3.hpp>
+#include <glm/vec4.hpp>
+#include <glm/mat2x2.hpp>
+#include <glm/mat3x3.hpp>
+#include <glm/mat4x4.hpp>
+
+#include <string>
+
+namespace rg {
+
+class Shader {
+public:
+    static Shader compile(const std::string& vertex_source,
+                          const std::string& fragment_source);
+    ~Shader();
+    void bind() const;
+    void unbind() const;
+
+    void set(const std::string& uniform, float value);
+    void set(const std::string& uniform, const glm::vec2& value);
+    void set(const std::string& uniform, const glm::vec3& value);
+    void set(const std::string& uniform, const glm::vec4& value);
+    void set(const std::string& uniform, const glm::mat2x2& value);
+    void set(const std::string& uniform, const glm::mat3x3& value);
+    void set(const std::string& uniform, const glm::mat4x4& value);
+private:
+    // NOLINTNEXTLINE(google-explicit-constructor)
+    Shader(unsigned int id);
+    int get_uniform_location(const std::string& name);
+    unsigned int shader_id_;
+};
+
+} // namespace rg
+
+#endif // RG_RENDERER_SHADER_SHADER_HPP

--- a/include/rg/util/read_file.hpp
+++ b/include/rg/util/read_file.hpp
@@ -1,0 +1,12 @@
+#ifndef RG_UTIL_READ_FILE_HPP
+#define RG_UTIL_READ_FILE_HPP
+
+#include <string>
+
+namespace rg::util {
+
+std::string readFile(const std::string& path);
+
+} // namespace rg::util
+
+#endif // RG_UTIL_READ_FILE_HPP

--- a/res/shaders/example.fs.glsl
+++ b/res/shaders/example.fs.glsl
@@ -1,0 +1,7 @@
+#version 460 core
+
+out vec4 fragColor;
+
+void main() {
+    fragColor = vec4(1.0f, 1.0f, 1.0f, 1.0f);
+}

--- a/res/shaders/example.vs.glsl
+++ b/res/shaders/example.vs.glsl
@@ -1,0 +1,9 @@
+#version 460 core
+
+layout (location = 0) in vec2 aPos;
+uniform mat2 rot;
+
+void main() {
+    vec2 tmp = rot * aPos;
+    gl_Position = vec4(tmp.x, tmp.y, 0.0f, 1.0f);
+}

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -11,7 +11,9 @@ set(SOURCES
         ${SOURCE_DIR}/renderer/buffer/VertexLayout.cpp
         ${SOURCE_DIR}/renderer/buffer/VertexArray.cpp
         ${SOURCE_DIR}/util/layout_elements.cpp
-        ${SOURCE_DIR}/util/read_file.cpp)
+        ${SOURCE_DIR}/util/read_file.cpp
+        ${SOURCE_DIR}/renderer/shader/Shader.cpp
+        ${SOURCE_DIR}/renderer/shader/Shader_set.cpp)
 set(HEADERS
         ${HEADER_DIR}/model/Ball.hpp
         ${HEADER_DIR}/model/Court.hpp
@@ -20,7 +22,8 @@ set(HEADERS
         ${HEADER_DIR}/renderer/buffer/VertexLayout.hpp
         ${HEADER_DIR}/renderer/buffer/VertexArray.hpp
         ${HEADER_DIR}/util/layout_elements.hpp
-        ${HEADER_DIR}/util/read_file.hpp)
+        ${HEADER_DIR}/util/read_file.hpp
+        ${HEADER_DIR}/renderer/shader/Shader.hpp)
 set(FILES ${SOURCES} ${HEADERS})
 
 set(EXECUTABLE rg)
@@ -32,6 +35,8 @@ find_package(glm REQUIRED)
 # ASSIMP
 set(CMAKE_POLICY_DEFAULT_CMP0012 NEW)
 find_package(ASSIMP REQUIRED)
+# SPDLOG
+find_package(spdlog)
 
 # Group the dependencies
 set(LIBRARIES
@@ -39,7 +44,8 @@ set(LIBRARIES
         glad
         glm::glm
         assimp
-        stb_image)
+        stb_image
+        spdlog)
 
 add_executable(${EXECUTABLE}
         ${FILES})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -10,7 +10,8 @@ set(SOURCES
         ${SOURCE_DIR}/renderer/buffer/VertexBuffer.cpp
         ${SOURCE_DIR}/renderer/buffer/VertexLayout.cpp
         ${SOURCE_DIR}/renderer/buffer/VertexArray.cpp
-        ${SOURCE_DIR}/util/layout_elements.cpp)
+        ${SOURCE_DIR}/util/layout_elements.cpp
+        ${SOURCE_DIR}/util/read_file.cpp)
 set(HEADERS
         ${HEADER_DIR}/model/Ball.hpp
         ${HEADER_DIR}/model/Court.hpp
@@ -18,7 +19,8 @@ set(HEADERS
         ${HEADER_DIR}/renderer/buffer/VertexBuffer.hpp
         ${HEADER_DIR}/renderer/buffer/VertexLayout.hpp
         ${HEADER_DIR}/renderer/buffer/VertexArray.hpp
-        ${HEADER_DIR}/util/layout_elements.hpp)
+        ${HEADER_DIR}/util/layout_elements.hpp
+        ${HEADER_DIR}/util/read_file.hpp)
 set(FILES ${SOURCES} ${HEADERS})
 
 set(EXECUTABLE rg)
@@ -47,7 +49,9 @@ target_include_directories(${EXECUTABLE}
 target_link_libraries(${EXECUTABLE}
         PRIVATE ${LIBRARIES})
 target_compile_definitions(${EXECUTABLE}
-        PRIVATE GLFW_INCLUDE_NONE)
+        PRIVATE
+        GLFW_INCLUDE_NONE
+        RESOURCE_DIRECTORY="${RESOURCE_OUTPUT_DIRECTORY}")
 
 # Copy resources to build directory
 # message(STATUS "RESOURCE LIST: ${RESOURCE_LIST}")

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -7,34 +7,13 @@
 #include <iostream>
 #include <string>
 
-#include <rg/renderer/buffer/VertexBuffer.hpp>
 #include <rg/renderer/buffer/IndexBuffer.hpp>
+#include <rg/renderer/buffer/VertexArray.hpp>
+#include <rg/renderer/buffer/VertexBuffer.hpp>
 #include <rg/renderer/buffer/VertexLayout.hpp>
 #include <rg/util/layout_elements.hpp>
-#include <rg/renderer/buffer/VertexArray.hpp>
 
-const std::string vs = "#version 460 core"
-R"S(
-layout (location = 0) in vec2 aPos;
-layout (location = 1) in vec3 aCol;
-
-out vec3 col;
-
-void main() {
-    gl_Position = vec4(aPos.x, aPos.y, 0.0f, 1.0f);
-    col = aCol;
-}
-)S";
-
-const std::string fs = "#version 460 core"
-                       R"S(
-in vec3 col;
-out vec4 fragColor;
-
-void main() {
-    fragColor = vec4(col.x, col.y, col.z, 1.0f);
-}
-)S";
+#include <rg/util/read_file.hpp>
 
 int main() {
     if (glfwInit() != GLFW_TRUE)
@@ -55,6 +34,12 @@ int main() {
         return 1;
     }
 
+    std::string resource_dir = RESOURCE_DIRECTORY;
+    std::string vs =
+            rg::util::readFile(resource_dir + "/shaders/example.vs.glsl");
+    std::string fs =
+            rg::util::readFile(resource_dir + "/shaders/example.fs.glsl");
+
     unsigned int VSID = glCreateShader(GL_VERTEX_SHADER);
     const char* text = vs.c_str();
     glShaderSource(VSID, 1, &text, nullptr);
@@ -70,30 +55,25 @@ int main() {
     int success;
     char infoLog[512];
     glGetProgramiv(shader, GL_LINK_STATUS, &success);
-    if (!success)
-    {
+    if (!success) {
         glGetShaderInfoLog(shader, 512, nullptr, infoLog);
-        std::cout << "ERROR::SHADER::VERTEX::COMPILATION_FAILED\n" << infoLog << std::endl;
+        std::cout << "ERROR::SHADER::VERTEX::COMPILATION_FAILED\n"
+                  << infoLog << std::endl;
     }
     glUseProgram(shader);
 
-    float vertices[] = {
-            // x, y, r, g, b
-            -0.5f, -0.5f, 1.0f, 0.0f, 0.0f,
-            0.5f, -0.5f, 0.0f, 1.0f, 0.0f,
-            0.5f, 0.5f, 0.0f, 0.0f, 1.0f,
-            -0.5f, 0.5f, 1.0f, 1.0f, 0.0f
-    };
+    float vertices[] = {// x, y, r, g, b
+                        -0.5f, -0.5f, 1.0f, 0.0f, 0.0f, 0.5f, -0.5f,
+                        0.0f,  1.0f,  0.0f, 0.5f, 0.5f, 0.0f, 0.0f,
+                        1.0f,  -0.5f, 0.5f, 1.0f, 1.0f, 0.0f};
 
-    unsigned int indices[] = {
-            0, 1, 2,
-            0, 2, 3
-    };
+    unsigned int indices[] = {0, 1, 2, 0, 2, 3};
 
     using rg::util::element;
     auto* VA = new rg::VertexArray();
-    auto* layout = new rg::VertexLayout{element<glm::vec2>(), element<glm::vec3>()};
-    auto* VB = new rg::VertexBuffer{vertices, sizeof (vertices)};
+    auto* layout =
+            new rg::VertexLayout{element<glm::vec2>(), element<glm::vec3>()};
+    auto* VB = new rg::VertexBuffer{vertices, sizeof(vertices)};
     auto* IB = new rg::IndexBuffer{indices, 6};
     VA->recordLayout(*VB, *layout);
     VA->unbind();
@@ -103,7 +83,7 @@ int main() {
     auto keyCallback = [](GLFWwindow* window, int key, int scancode, int action,
                           int mods) {
         if (key == GLFW_KEY_ESCAPE && action == GLFW_PRESS)
-          glfwSetWindowShouldClose(window, GLFW_TRUE);
+            glfwSetWindowShouldClose(window, GLFW_TRUE);
     };
     glfwSetKeyCallback(window, keyCallback);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,6 +3,9 @@
 
 #include <glm/vec2.hpp>
 #include <glm/vec3.hpp>
+#include <glm/ext/scalar_constants.hpp>
+#include <glm/trigonometric.hpp>
+#include <glm/gtc/matrix_transform.hpp>
 
 #include <iostream>
 #include <string>
@@ -12,6 +15,7 @@
 #include <rg/renderer/buffer/VertexBuffer.hpp>
 #include <rg/renderer/buffer/VertexLayout.hpp>
 #include <rg/util/layout_elements.hpp>
+#include <rg/renderer/shader/Shader.hpp>
 
 #include <rg/util/read_file.hpp>
 
@@ -21,7 +25,7 @@ int main() {
 
     glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 4);
     glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 6);
-    GLFWwindow* window = glfwCreateWindow(800, 600, "Test", nullptr, nullptr);
+    GLFWwindow* window = glfwCreateWindow(600, 600, "Test", nullptr, nullptr);
     if (window == nullptr) {
         glfwTerminate();
         return 1;
@@ -34,63 +38,56 @@ int main() {
         return 1;
     }
 
+    auto keyCallback = [](GLFWwindow* window, int key, int scancode, int action,
+                          int mods) {
+      if (key == GLFW_KEY_ESCAPE && action == GLFW_PRESS)
+          glfwSetWindowShouldClose(window, GLFW_TRUE);
+    };
+    glfwSetKeyCallback(window, keyCallback);
+
+    float vertices[] = {
+            0.5f * glm::cos(glm::pi<float>() / 2.0f),
+            0.5f * glm::sin(glm::pi<float>() / 2.0f),
+            0.5f * glm::cos(-5.0f * glm::pi<float>() / 6.0f),
+            0.5f * glm::sin(-5.0f * glm::pi<float>() / 6.0f),
+            0.5f * glm::cos(-glm::pi<float>() / 6.0f),
+            0.5f * glm::sin(-glm::pi<float>() / 6.0f)
+    };
+
+    unsigned int indices[] = {0, 1, 2};
+
+    using rg::util::element;
+    auto* VA = new rg::VertexArray();
+    auto* layout =
+            new rg::VertexLayout{element<glm::vec2>()};
+    auto* VB = new rg::VertexBuffer{vertices, sizeof (vertices)};
+    auto* IB = new rg::IndexBuffer{indices, sizeof (indices) / sizeof (indices[0])};
+    VA->recordLayout(*VB, *layout);
+    VA->unbind();
+    VB->unbind();
+    IB->unbind();
+
     std::string resource_dir = RESOURCE_DIRECTORY;
     std::string vs =
             rg::util::readFile(resource_dir + "/shaders/example.vs.glsl");
     std::string fs =
             rg::util::readFile(resource_dir + "/shaders/example.fs.glsl");
 
-    unsigned int VSID = glCreateShader(GL_VERTEX_SHADER);
-    const char* text = vs.c_str();
-    glShaderSource(VSID, 1, &text, nullptr);
-    glCompileShader(VSID);
-    unsigned int FSID = glCreateShader(GL_FRAGMENT_SHADER);
-    text = fs.c_str();
-    glShaderSource(FSID, 1, &text, nullptr);
-    glCompileShader(FSID);
-    unsigned int shader = glCreateProgram();
-    glAttachShader(shader, VSID);
-    glAttachShader(shader, FSID);
-    glLinkProgram(shader);
-    int success;
-    char infoLog[512];
-    glGetProgramiv(shader, GL_LINK_STATUS, &success);
-    if (!success) {
-        glGetShaderInfoLog(shader, 512, nullptr, infoLog);
-        std::cout << "ERROR::SHADER::VERTEX::COMPILATION_FAILED\n"
-                  << infoLog << std::endl;
-    }
-    glUseProgram(shader);
+    auto* shader = new rg::Shader{rg::Shader::compile(vs, fs)};
+    shader->bind();
 
-    float vertices[] = {// x, y, r, g, b
-                        -0.5f, -0.5f, 1.0f, 0.0f, 0.0f, 0.5f, -0.5f,
-                        0.0f,  1.0f,  0.0f, 0.5f, 0.5f, 0.0f, 0.0f,
-                        1.0f,  -0.5f, 0.5f, 1.0f, 1.0f, 0.0f};
-
-    unsigned int indices[] = {0, 1, 2, 0, 2, 3};
-
-    using rg::util::element;
-    auto* VA = new rg::VertexArray();
-    auto* layout =
-            new rg::VertexLayout{element<glm::vec2>(), element<glm::vec3>()};
-    auto* VB = new rg::VertexBuffer{vertices, sizeof(vertices)};
-    auto* IB = new rg::IndexBuffer{indices, 6};
-    VA->recordLayout(*VB, *layout);
-    VA->unbind();
-    VB->unbind();
-    IB->unbind();
-
-    auto keyCallback = [](GLFWwindow* window, int key, int scancode, int action,
-                          int mods) {
-        if (key == GLFW_KEY_ESCAPE && action == GLFW_PRESS)
-            glfwSetWindowShouldClose(window, GLFW_TRUE);
-    };
-    glfwSetKeyCallback(window, keyCallback);
+    glm::mat2x2 rot{1.0f};
+    shader->set("rot", rot);
 
     glClearColor(0.0f, 0.0f, 0.0f, 1.0f);
     while (!glfwWindowShouldClose(window)) {
         glClear(GL_COLOR_BUFFER_BIT);
 
+        double time = glfwGetTime();
+        rot = {glm::cos(time), glm::sin(time), -glm::sin(time), glm::cos(time)};
+        shader->set("rot", rot);
+
+        shader->bind();
         VA->bind();
         glDrawElements(GL_TRIANGLES, IB->count(), GL_UNSIGNED_INT, nullptr);
         VA->unbind();
@@ -103,6 +100,7 @@ int main() {
     delete VA;
     delete IB;
     delete VB;
+    // delete shader;
 
     glfwTerminate();
     return 0;

--- a/src/renderer/shader/Shader.cpp
+++ b/src/renderer/shader/Shader.cpp
@@ -65,7 +65,7 @@ Shader Shader::compile(const std::string& vertexSource,
     return Shader{program};
 }
 
-int Shader::get_uniform_location(const std::string& name) {
+int Shader::get_uniform_location(const std::string& name) const {
     int location = glGetUniformLocation(shader_id_, name.c_str());
     if (location == -1)
         spdlog::warn("RG::SHADER::GET_LOCATION: location for uniform {} is "

--- a/src/renderer/shader/Shader.cpp
+++ b/src/renderer/shader/Shader.cpp
@@ -1,0 +1,93 @@
+#include <rg/renderer/shader/Shader.hpp>
+
+#include <glad/glad.h>
+
+#include <spdlog/spdlog.h>
+
+namespace rg {
+
+namespace {
+
+unsigned int compileShader(unsigned int type, const std::string& source) {
+    const char* c_string_source = source.c_str();
+    unsigned int id = glCreateShader(type);
+    glShaderSource(id, 1, &c_string_source, nullptr);
+    glCompileShader(id);
+
+    int success, required_size;
+    glGetShaderiv(id, GL_COMPILE_STATUS, &success);
+    if (success == GL_FALSE) {
+        glGetShaderiv(id, GL_INFO_LOG_LENGTH, &required_size);
+        std::vector<char> tmp(required_size);
+        glGetShaderInfoLog(id, required_size, nullptr, tmp.data());
+        std::string error(tmp.begin(), tmp.end());
+
+        spdlog::error("RG::SHADER::COMPILE_SHADER: {}", error);
+        return 0;
+    }
+
+    return id;
+}
+
+unsigned int linkProgram(unsigned int vs, unsigned int fs) {
+    unsigned int id = glCreateProgram();
+    glAttachShader(id, vs);
+    glAttachShader(id, fs);
+    glLinkProgram(id);
+
+    int success, required_size;
+    glGetProgramiv(id, GL_COMPILE_STATUS, &success);
+    if (success == GL_FALSE) {
+        glGetProgramiv(id, GL_INFO_LOG_LENGTH, &required_size);
+        std::vector<char> tmp(required_size);
+        glGetProgramInfoLog(id, required_size, nullptr, tmp.data());
+        std::string error(tmp.begin(), tmp.end());
+
+        spdlog::error("RG::SHADER::LINK_PROGRAM: {}", error);
+    }
+
+    return id;
+}
+
+} // namespace
+
+Shader Shader::compile(const std::string& vertexSource,
+                       const std::string& fragmentSource) {
+    unsigned int vs = compileShader(GL_VERTEX_SHADER, vertexSource);
+    unsigned int fs = compileShader(GL_FRAGMENT_SHADER, fragmentSource);
+    unsigned int program = linkProgram(vs, fs);
+
+    glUseProgram(program);
+
+    glDeleteShader(vs);
+    glDeleteShader(fs);
+
+    return Shader{program};
+}
+
+int Shader::get_uniform_location(const std::string& name) {
+    int location = glGetUniformLocation(shader_id_, name.c_str());
+    if (location == -1)
+        spdlog::warn("RG::SHADER::GET_LOCATION: location for uniform {} is "
+                     "non-existant",
+                     name);
+    return location;
+}
+
+void Shader::bind() const {
+    glUseProgram(shader_id_);
+}
+
+// NOLINTNEXTLINE(readability-convert-member-functions-to-static)
+void Shader::unbind() const {
+    glUseProgram(0);
+}
+
+Shader::Shader(unsigned int id) : shader_id_{id} {
+}
+
+Shader::~Shader() {
+    glDeleteProgram(shader_id_);
+}
+
+} // namespace rg

--- a/src/renderer/shader/Shader.cpp
+++ b/src/renderer/shader/Shader.cpp
@@ -69,7 +69,7 @@ int Shader::get_uniform_location(const std::string& name) const {
     int location = glGetUniformLocation(shader_id_, name.c_str());
     if (location == -1)
         spdlog::warn("RG::SHADER::GET_LOCATION: location for uniform {} is "
-                     "non-existant",
+                     "non-existent",
                      name);
     return location;
 }

--- a/src/renderer/shader/Shader.cpp
+++ b/src/renderer/shader/Shader.cpp
@@ -36,7 +36,7 @@ unsigned int linkProgram(unsigned int vs, unsigned int fs) {
     glLinkProgram(id);
 
     int success, required_size;
-    glGetProgramiv(id, GL_COMPILE_STATUS, &success);
+    glGetProgramiv(id, GL_LINK_STATUS, &success);
     if (success == GL_FALSE) {
         glGetProgramiv(id, GL_INFO_LOG_LENGTH, &required_size);
         std::vector<char> tmp(required_size);
@@ -67,10 +67,12 @@ Shader Shader::compile(const std::string& vertexSource,
 
 int Shader::get_uniform_location(const std::string& name) const {
     int location = glGetUniformLocation(shader_id_, name.c_str());
-    if (location == -1)
-        spdlog::warn("RG::SHADER::GET_LOCATION: location for uniform {} is "
-                     "non-existent",
-                     name);
+    if (location == -1) {
+        //        spdlog::warn("RG::SHADER::GET_LOCATION: location for uniform
+        //        {} is "
+        //                     "non-existent",
+        //                     name);
+    }
     return location;
 }
 

--- a/src/renderer/shader/Shader_set.cpp
+++ b/src/renderer/shader/Shader_set.cpp
@@ -12,6 +12,13 @@ void Shader::set(const std::string& uniform, float value) const {
     }
 }
 
+void Shader::set(const std::string& uniform, int value) const {
+    int location = get_uniform_location(uniform);
+    if (location != -1) {
+        glUniform1i(location, value);
+    }
+}
+
 void Shader::set(const std::string& uniform, const glm::vec2& value) const {
     int location = get_uniform_location(uniform);
     if (location != -1) {

--- a/src/renderer/shader/Shader_set.cpp
+++ b/src/renderer/shader/Shader_set.cpp
@@ -1,0 +1,57 @@
+#include <rg/renderer/shader/Shader.hpp>
+
+#include <glad/glad.h>
+#include <glm/gtc/type_ptr.hpp>
+
+namespace rg {
+
+void Shader::set(const std::string& uniform, float value) {
+    int location = get_uniform_location(uniform);
+    if (location != -1) {
+        glUniform1f(location, value);
+    }
+}
+
+void Shader::set(const std::string& uniform, const glm::vec2& value) {
+    int location = get_uniform_location(uniform);
+    if (location != -1) {
+        glUniform2fv(location, 1, glm::value_ptr(value));
+    }
+}
+
+void Shader::set(const std::string& uniform, const glm::vec3& value) {
+    int location = get_uniform_location(uniform);
+    if (location != -1) {
+        glUniform3fv(location, 1, glm::value_ptr(value));
+    }
+}
+
+void Shader::set(const std::string& uniform, const glm::vec4& value) {
+    int location = get_uniform_location(uniform);
+    if (location != -1) {
+        glUniform4fv(location, 1, glm::value_ptr(value));
+    }
+}
+
+void Shader::set(const std::string& uniform, const glm::mat2x2& value) {
+    int location = get_uniform_location(uniform);
+    if (location != -1) {
+        glUniformMatrix2fv(location, 1, GL_FALSE, glm::value_ptr(value));
+    }
+}
+
+void Shader::set(const std::string& uniform, const glm::mat3x3& value) {
+    int location = get_uniform_location(uniform);
+    if (location != -1) {
+        glUniformMatrix3fv(location, 1, GL_FALSE, glm::value_ptr(value));
+    }
+}
+
+void Shader::set(const std::string& uniform, const glm::mat4x4& value) {
+    int location = get_uniform_location(uniform);
+    if (location != -1) {
+        glUniformMatrix4fv(location, 1, GL_FALSE, glm::value_ptr(value));
+    }
+}
+
+};

--- a/src/renderer/shader/Shader_set.cpp
+++ b/src/renderer/shader/Shader_set.cpp
@@ -5,49 +5,49 @@
 
 namespace rg {
 
-void Shader::set(const std::string& uniform, float value) {
+void Shader::set(const std::string& uniform, float value) const {
     int location = get_uniform_location(uniform);
     if (location != -1) {
         glUniform1f(location, value);
     }
 }
 
-void Shader::set(const std::string& uniform, const glm::vec2& value) {
+void Shader::set(const std::string& uniform, const glm::vec2& value) const {
     int location = get_uniform_location(uniform);
     if (location != -1) {
         glUniform2fv(location, 1, glm::value_ptr(value));
     }
 }
 
-void Shader::set(const std::string& uniform, const glm::vec3& value) {
+void Shader::set(const std::string& uniform, const glm::vec3& value) const {
     int location = get_uniform_location(uniform);
     if (location != -1) {
         glUniform3fv(location, 1, glm::value_ptr(value));
     }
 }
 
-void Shader::set(const std::string& uniform, const glm::vec4& value) {
+void Shader::set(const std::string& uniform, const glm::vec4& value) const {
     int location = get_uniform_location(uniform);
     if (location != -1) {
         glUniform4fv(location, 1, glm::value_ptr(value));
     }
 }
 
-void Shader::set(const std::string& uniform, const glm::mat2x2& value) {
+void Shader::set(const std::string& uniform, const glm::mat2x2& value) const {
     int location = get_uniform_location(uniform);
     if (location != -1) {
         glUniformMatrix2fv(location, 1, GL_FALSE, glm::value_ptr(value));
     }
 }
 
-void Shader::set(const std::string& uniform, const glm::mat3x3& value) {
+void Shader::set(const std::string& uniform, const glm::mat3x3& value) const {
     int location = get_uniform_location(uniform);
     if (location != -1) {
         glUniformMatrix3fv(location, 1, GL_FALSE, glm::value_ptr(value));
     }
 }
 
-void Shader::set(const std::string& uniform, const glm::mat4x4& value) {
+void Shader::set(const std::string& uniform, const glm::mat4x4& value) const {
     int location = get_uniform_location(uniform);
     if (location != -1) {
         glUniformMatrix4fv(location, 1, GL_FALSE, glm::value_ptr(value));

--- a/src/renderer/shader/Shader_set.cpp
+++ b/src/renderer/shader/Shader_set.cpp
@@ -54,4 +54,4 @@ void Shader::set(const std::string& uniform, const glm::mat4x4& value) {
     }
 }
 
-};
+}; // namespace rg

--- a/src/util/read_file.cpp
+++ b/src/util/read_file.cpp
@@ -1,0 +1,16 @@
+#include <rg/util/read_file.hpp>
+
+#include <string>
+#include <fstream>
+#include <sstream>
+
+namespace rg::util {
+
+std::string readFile(const std::string& path) {
+    std::fstream file{path};
+    std::stringstream medium{};
+    medium << file.rdbuf();
+    return medium.str();
+}
+
+} // namespace rg::util


### PR DESCRIPTION
Set up CMake to copy `res/` folder to the build directory when building;

Created simple Shader framework which supports:
- Compiling and linking shader components (vertex, fragment)
- Compilation and linking error logging (with `spdlog`)
- Binding and unbinding
- Uniform setting for common types;

Added a utility function to read files into C++ strings